### PR TITLE
Fixing overloaded function error

### DIFF
--- a/Software/src/main.cpp
+++ b/Software/src/main.cpp
@@ -1492,7 +1492,7 @@ void setup()
 
 	MenuHeader("LoraType");
 
-	Wire.begin(PinSDA, PinSCL, 100000);
+	Wire.begin(PinSDA, PinSCL, (uint32_t)100000);
 	delay(200);
 
 	key_matrix.begin();


### PR DESCRIPTION
To fix the issue, I typecast 100000 as a uint32_t allowing the compiler to understand which function to use. My small change will not affect anything even if no one else has this issue. Below is the error I received.

src/main.cpp:1495:35: error: call of overloaded 'begin(int, int, int)' is ambiguous
  Wire.begin(PinSDA, PinSCL, 100000);
                                   ^
In file included from src/Tca8418Keyboard.h:5,
                 from src/main.h:12,
                 from src/main.cpp:1:
C:/XXXX/.platformio/packages/framework-arduinoespressif32/libraries/Wire/src/Wire.h:79:10: note: candidate: 'bool TwoWire::begin(int, int, uint32_t)'
     bool begin(int sda=-1, int scl=-1, uint32_t frequency=0); // returns true, if successful init of i2c bus
          ^~~~~
C:/XXXX/.platformio/packages/framework-arduinoespressif32/libraries/Wire/src/Wire.h:80:10: note: candidate: 'bool TwoWire::begin(uint8_t, int, int, uint32_t)'
     bool begin(uint8_t slaveAddr, int sda=-1, int scl=-1, uint32_t frequency=0);